### PR TITLE
URL Cleanup

### DIFF
--- a/test/check_token.sh
+++ b/test/check_token.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-token=$(curl -fv "http://guest:guest@localhost:8000/endpoint/$1?hub.mode=generate_token&hub.intended_use=$2")
+token=$(curl -fv "https://guest:guest@localhost:8000/endpoint/$1?hub.mode=generate_token&hub.intended_use=$2")
 if [ $? = 0 ]
 then
     curl -v "http://localhost:8000/endpoint/$1?hub.mode=$2&hub.topic=&${token}"

--- a/test/create_q.sh
+++ b/test/create_q.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -X PUT http://guest:guest@localhost:8000/endpoint/q/"$1"
+curl -X PUT https://guest:guest@localhost:8000/endpoint/q/"$1"

--- a/test/create_x.sh
+++ b/test/create_x.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -X PUT http://guest:guest@localhost:8000/endpoint/x/"$1"
+curl -X PUT https://guest:guest@localhost:8000/endpoint/x/"$1"

--- a/test/delete_q.sh
+++ b/test/delete_q.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -X DELETE http://guest:guest@localhost:8000/endpoint/q/"$1"
+curl -X DELETE https://guest:guest@localhost:8000/endpoint/q/"$1"

--- a/test/delete_x.sh
+++ b/test/delete_x.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -X DELETE http://guest:guest@localhost:8000/endpoint/x/"$1"
+curl -X DELETE https://guest:guest@localhost:8000/endpoint/x/"$1"

--- a/test/generate_token.sh
+++ b/test/generate_token.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl "http://guest:guest@localhost:8000/endpoint/$1?hub.mode=generate_token&hub.intended_use=$2"
+curl "https://guest:guest@localhost:8000/endpoint/$1?hub.mode=generate_token&hub.intended_use=$2"

--- a/test/send_q_foo.sh
+++ b/test/send_q_foo.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -d "$1" http://guest:guest@localhost:8000/endpoint/q/foo?hub.topic=rk
+curl -d "$1" https://guest:guest@localhost:8000/endpoint/q/foo?hub.topic=rk

--- a/test/send_x_foo.sh
+++ b/test/send_x_foo.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -d "$1" http://guest:guest@localhost:8000/endpoint/x/amq.direct?hub.topic=foo
+curl -d "$1" https://guest:guest@localhost:8000/endpoint/x/amq.direct?hub.topic=foo

--- a/test/shortcut_sub.sh
+++ b/test/shortcut_sub.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-token=$(curl -fv "http://guest:guest@localhost:8000/endpoint/q/foo?hub.mode=generate_token&hub.intended_use=subscribe")
+token=$(curl -fv "https://guest:guest@localhost:8000/endpoint/q/foo?hub.mode=generate_token&hub.intended_use=subscribe")
 if [ $? = 0 ]
 then
-    curl -vd "hub.mode=subscribe&hub.callback=http://localhost:8000/endpoint/q/foo&hub.topic=foo&hub.verify=sync&hub.verify=async&${token}" http://guest:guest@localhost:8000/subscribe/x/amq.direct
+    curl -vd "hub.mode=subscribe&hub.callback=http://localhost:8000/endpoint/q/foo&hub.topic=foo&hub.verify=sync&hub.verify=async&${token}" https://guest:guest@localhost:8000/subscribe/x/amq.direct
 else
     echo "Token generation failed"
 fi

--- a/test/shortcut_unsub.sh
+++ b/test/shortcut_unsub.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-token=$(curl -fv "http://guest:guest@localhost:8000/endpoint/q/foo?hub.mode=generate_token&hub.intended_use=unsubscribe")
+token=$(curl -fv "https://guest:guest@localhost:8000/endpoint/q/foo?hub.mode=generate_token&hub.intended_use=unsubscribe")
 if [ $? = 0 ]
 then
-    curl -vd "hub.mode=unsubscribe&hub.callback=http://localhost:8000/endpoint/q/foo&hub.topic=foo&hub.verify=sync&hub.verify=async&${token}" http://guest:guest@localhost:8000/subscribe/x/amq.direct
+    curl -vd "hub.mode=unsubscribe&hub.callback=http://localhost:8000/endpoint/q/foo&hub.topic=foo&hub.verify=sync&hub.verify=async&${token}" https://guest:guest@localhost:8000/subscribe/x/amq.direct
 else
     echo "Token generation failed"
 fi

--- a/test/sub_q_foo.sh
+++ b/test/sub_q_foo.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -vd "hub.mode=subscribe&hub.callback=http://localhost:8888/sub2&hub.topic=foo&hub.verify=sync&hub.lease_seconds=10" http://guest:guest@localhost:8000/subscribe/q/foo
+curl -vd "hub.mode=subscribe&hub.callback=http://localhost:8888/sub2&hub.topic=foo&hub.verify=sync&hub.lease_seconds=10" https://guest:guest@localhost:8000/subscribe/q/foo

--- a/test/sub_x_foo.sh
+++ b/test/sub_x_foo.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -vd "hub.mode=subscribe&hub.callback=http://localhost:8888/sub1&hub.topic=foo&hub.verify=sync&hub.verify=async" http://guest:guest@localhost:8000/subscribe/x/amq.direct
+curl -vd "hub.mode=subscribe&hub.callback=http://localhost:8888/sub1&hub.topic=foo&hub.verify=sync&hub.verify=async" https://guest:guest@localhost:8000/subscribe/x/amq.direct


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://guest:guest@localhost:8000/endpoint/ (UnknownHostException) migrated to:  
  https://guest:guest@localhost:8000/endpoint/ ([https](https://guest:guest@localhost:8000/endpoint/) result UnknownHostException).
* http://guest:guest@localhost:8000/endpoint/q/ (UnknownHostException) migrated to:  
  https://guest:guest@localhost:8000/endpoint/q/ ([https](https://guest:guest@localhost:8000/endpoint/q/) result UnknownHostException).
* http://guest:guest@localhost:8000/endpoint/q/foo?hub.mode=generate_token&hub.intended_use=subscribe (UnknownHostException) migrated to:  
  https://guest:guest@localhost:8000/endpoint/q/foo?hub.mode=generate_token&hub.intended_use=subscribe ([https](https://guest:guest@localhost:8000/endpoint/q/foo?hub.mode=generate_token&hub.intended_use=subscribe) result UnknownHostException).
* http://guest:guest@localhost:8000/endpoint/q/foo?hub.mode=generate_token&hub.intended_use=unsubscribe (UnknownHostException) migrated to:  
  https://guest:guest@localhost:8000/endpoint/q/foo?hub.mode=generate_token&hub.intended_use=unsubscribe ([https](https://guest:guest@localhost:8000/endpoint/q/foo?hub.mode=generate_token&hub.intended_use=unsubscribe) result UnknownHostException).
* http://guest:guest@localhost:8000/endpoint/q/foo?hub.topic=rk (UnknownHostException) migrated to:  
  https://guest:guest@localhost:8000/endpoint/q/foo?hub.topic=rk ([https](https://guest:guest@localhost:8000/endpoint/q/foo?hub.topic=rk) result UnknownHostException).
* http://guest:guest@localhost:8000/endpoint/x/ (UnknownHostException) migrated to:  
  https://guest:guest@localhost:8000/endpoint/x/ ([https](https://guest:guest@localhost:8000/endpoint/x/) result UnknownHostException).
* http://guest:guest@localhost:8000/endpoint/x/amq.direct?hub.topic=foo (UnknownHostException) migrated to:  
  https://guest:guest@localhost:8000/endpoint/x/amq.direct?hub.topic=foo ([https](https://guest:guest@localhost:8000/endpoint/x/amq.direct?hub.topic=foo) result UnknownHostException).
* http://guest:guest@localhost:8000/subscribe/q/foo (UnknownHostException) migrated to:  
  https://guest:guest@localhost:8000/subscribe/q/foo ([https](https://guest:guest@localhost:8000/subscribe/q/foo) result UnknownHostException).
* http://guest:guest@localhost:8000/subscribe/x/amq.direct (UnknownHostException) migrated to:  
  https://guest:guest@localhost:8000/subscribe/x/amq.direct ([https](https://guest:guest@localhost:8000/subscribe/x/amq.direct) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8000/endpoint/
* http://localhost:8000/endpoint/q/foo&hub.topic=foo&hub.verify=sync&hub.verify=async&
* http://localhost:8888/sub1&hub.topic=foo&hub.verify=sync&hub.verify=async
* http://localhost:8888/sub2&hub.topic=foo&hub.verify=sync&hub.lease_seconds=10