### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ queue, and one to use to subscribe to messages forwarded on by the
 exchange or queue. You subscribe with a callback URL, so when messages
 arrive, RabbitHub POSTs them on to your callback. For example,
 
- - <http://dev.rabbitmq.com/rabbithub/endpoint/x/amq.direct> is the
+ - <https://dev.rabbitmq.com/rabbithub/endpoint/x/amq.direct> is the
    URL for delivering messages to the "amq.direct" exchange on the
    public test instance of RabbitMQ, and
 
- - <http://dev.rabbitmq.com/rabbithub/subscribe/q/some_queue_name> is
+ - <https://dev.rabbitmq.com/rabbithub/subscribe/q/some_queue_name> is
    the URL for subscribing to messages from the (hypothetical) queue
    "some_queue_name" on the broker.
 
@@ -44,13 +44,13 @@ message networks - for example, our public RabbitMQ instance,
 adapter, the [rabbitmq-xmpp][] plugin, and a bunch of our other
 experimental stuff, so you can do things like this:
 
-<img src="http://github.com/tonyg/rabbithub/raw/master/doc/rabbithub-example.png" alt="RabbitHub example configuration"/>
+<img src="https://github.com/tonyg/rabbithub/raw/master/doc/rabbithub-example.png" alt="RabbitHub example configuration"/>
 
  - become XMPP friends with `pshb@dev.rabbitmq.com` (the XMPP adapter
    gives each exchange a JID of its own)
 
  - use PubSubHubBub to subscribe the sink
-   <http://dev.rabbitmq.com/rabbithub/endpoint/x/pshb> to some
+   <https://dev.rabbitmq.com/rabbithub/endpoint/x/pshb> to some
    PubSubHubBub source - perhaps one on the public Google PSHB
    instance. (Note how the given URL ends in "x/pshb", meaning the
    "pshb" exchange - which lines up with the JID we just became XMPP
@@ -68,24 +68,24 @@ rather than anything intrinsic in pubsub-over-webhooks.
 ## HTTP messaging in the Browser
 
 In order to push AMQP messages out to a webpage running in a browser,
-try using <http://www.reversehttp.net/> to run a PubSubHubBub endpoint
+try using <https://reversehttp.net/> to run a PubSubHubBub endpoint
 in a webpage - see for instance
-<http://www.reversehttp.net/demos/endpoint.html> and its [associated
-Javascript](http://www.reversehttp.net/demos/endpoint.js) for a simple
+<https://reversehttp.net/demos/endpoint.html> and its [associated
+Javascript](https://reversehttp.net/demos/endpoint.js) for a simple
 prototype of the idea. It's also possible to build simple PSHB hubs in
 Javascript using the same tools.
 
-  [gitrepo]: http://github.com/tonyg/rabbithub
-  [pshb_project]: http://code.google.com/p/pubsubhubbub/
-  [spec]: http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.1.html
-  [RabbitMQ]: http://www.rabbitmq.com/
-  [rabbitmq-xmpp]: http://hg.rabbitmq.com/rabbitmq-xmpp/raw-file/default/doc/overview-summary.html
+  [gitrepo]: https://github.com/tonyg/rabbithub
+  [pshb_project]: https://code.google.com/p/pubsubhubbub/
+  [spec]: https://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.1.html
+  [RabbitMQ]: https://www.rabbitmq.com/
+  [rabbitmq-xmpp]: https://hg.rabbitmq.com/rabbitmq-xmpp/raw-file/default/doc/overview-summary.html
 
 ## Software License
 
-RabbitHub is [open-source](http://www.opensource.org/) code, licensed
+RabbitHub is [open-source](https://www.opensource.org/) code, licensed
 under the very liberal [MIT
-license](http://www.opensource.org/licenses/mit-license.php):
+license](https://www.opensource.org/licenses/mit-license.php):
 
     Copyright (c) 2009 Tony Garnock-Jones <tonyg@lshift.net>
     Copyright (c) 2009 LShift Ltd. <query@lshift.net>

--- a/TODO
+++ b/TODO
@@ -1,5 +1,5 @@
 Use WADL instead of the adhoc description language I cooked up:
-http://en.wikipedia.org/wiki/Web_Application_Description_Language
+https://en.wikipedia.org/wiki/Web_Application_Description_Language
 
 Encrypt the generated token. It contains too much free authority (the
 name of the underlying resource).


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://dev.rabbitmq.com/rabbithub/endpoint/x/amq.direct (UnknownHostException) with 1 occurrences migrated to:  
  https://dev.rabbitmq.com/rabbithub/endpoint/x/amq.direct ([https](https://dev.rabbitmq.com/rabbithub/endpoint/x/amq.direct) result UnknownHostException).
* http://dev.rabbitmq.com/rabbithub/endpoint/x/pshb (UnknownHostException) with 1 occurrences migrated to:  
  https://dev.rabbitmq.com/rabbithub/endpoint/x/pshb ([https](https://dev.rabbitmq.com/rabbithub/endpoint/x/pshb) result UnknownHostException).
* http://dev.rabbitmq.com/rabbithub/subscribe/q/some_queue_name (UnknownHostException) with 1 occurrences migrated to:  
  https://dev.rabbitmq.com/rabbithub/subscribe/q/some_queue_name ([https](https://dev.rabbitmq.com/rabbithub/subscribe/q/some_queue_name) result UnknownHostException).
* http://hg.rabbitmq.com/rabbitmq-xmpp/raw-file/default/doc/overview-summary.html (UnknownHostException) with 1 occurrences migrated to:  
  https://hg.rabbitmq.com/rabbitmq-xmpp/raw-file/default/doc/overview-summary.html ([https](https://hg.rabbitmq.com/rabbitmq-xmpp/raw-file/default/doc/overview-summary.html) result UnknownHostException).
* http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.1.html (404) with 1 occurrences migrated to:  
  https://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.1.html ([https](https://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.1.html) result 404).
* http://www.reversehttp.net/demos/endpoint.html (301) with 1 occurrences migrated to:  
  https://reversehttp.net/demos/endpoint.html ([https](https://www.reversehttp.net/demos/endpoint.html) result 404).
* http://www.reversehttp.net/demos/endpoint.js (301) with 1 occurrences migrated to:  
  https://reversehttp.net/demos/endpoint.js ([https](https://www.reversehttp.net/demos/endpoint.js) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://en.wikipedia.org/wiki/Web_Application_Description_Language with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Web_Application_Description_Language ([https](https://en.wikipedia.org/wiki/Web_Application_Description_Language) result 200).
* http://github.com/tonyg/rabbithub with 1 occurrences migrated to:  
  https://github.com/tonyg/rabbithub ([https](https://github.com/tonyg/rabbithub) result 200).
* http://www.reversehttp.net/ (301) with 1 occurrences migrated to:  
  https://reversehttp.net/ ([https](https://www.reversehttp.net/) result 200).
* http://www.rabbitmq.com/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/ ([https](https://www.rabbitmq.com/) result 200).
* http://code.google.com/p/pubsubhubbub/ with 1 occurrences migrated to:  
  https://code.google.com/p/pubsubhubbub/ ([https](https://code.google.com/p/pubsubhubbub/) result 301).
* http://www.opensource.org/ with 1 occurrences migrated to:  
  https://www.opensource.org/ ([https](https://www.opensource.org/) result 301).
* http://www.opensource.org/licenses/mit-license.php with 1 occurrences migrated to:  
  https://www.opensource.org/licenses/mit-license.php ([https](https://www.opensource.org/licenses/mit-license.php) result 301).
* http://github.com/tonyg/rabbithub/raw/master/doc/rabbithub-example.png with 1 occurrences migrated to:  
  https://github.com/tonyg/rabbithub/raw/master/doc/rabbithub-example.png ([https](https://github.com/tonyg/rabbithub/raw/master/doc/rabbithub-example.png) result 302).